### PR TITLE
Refusjonskrav omsorgspenger: År for refusjon skal kun kunne velges før 1. april hvert år

### DIFF
--- a/app/src/features/refusjon-omsorgspenger/steg/Steg1Intro.tsx
+++ b/app/src/features/refusjon-omsorgspenger/steg/Steg1Intro.tsx
@@ -18,6 +18,7 @@ import { useDocumentTitle } from "../../shared/hooks/useDocumentTitle.tsx";
 import { useScrollToTopOnMount } from "../../shared/hooks/useScrollToTopOnMount.tsx";
 import { useSkjemaState } from "../SkjemaStateContext.tsx";
 import { useInnloggetBruker } from "../useInnloggetBruker.tsx";
+import { ÅrForRefusjon } from "../visningskomponenter/ÅrForRefusjon.tsx";
 import { OmsorgspengerFremgangsindikator } from "../visningskomponenter/OmsorgspengerFremgangsindikator.tsx";
 
 export const RefusjonOmsorgspengerArbeidsgiverSteg1 = () => {
@@ -48,9 +49,6 @@ export const RefusjonOmsorgspengerArbeidsgiverSteg1 = () => {
 
   const { name: harUtbetaltLønnName, ...harUtbetaltLønnRadioGroupProps } =
     register("harUtbetaltLønn");
-
-  const { name: årForRefusjonName, ...årForRefusjonRadioGroupProps } =
-    register("årForRefusjon");
 
   return (
     <div className="bg-ax-bg-default rounded-md flex flex-col gap-6">
@@ -108,19 +106,7 @@ export const RefusjonOmsorgspengerArbeidsgiverSteg1 = () => {
               </BodyLong>
             </Alert>
           )}
-          <RadioGroup
-            error={formState.errors.årForRefusjon?.message}
-            legend="Hvilket år søker dere refusjon for?"
-            name={årForRefusjonName}
-          >
-            <Radio value={String(iFjor)} {...årForRefusjonRadioGroupProps}>
-              {iFjor}
-            </Radio>
-            <Radio value={String(iÅr)} {...årForRefusjonRadioGroupProps}>
-              {iÅr}
-            </Radio>
-          </RadioGroup>
-
+          <ÅrForRefusjon />
           <div>
             <Button
               disabled={harUtbetaltLønn === "nei"}

--- a/app/src/features/refusjon-omsorgspenger/steg/Steg1Intro.tsx
+++ b/app/src/features/refusjon-omsorgspenger/steg/Steg1Intro.tsx
@@ -18,7 +18,12 @@ import { useDocumentTitle } from "../../shared/hooks/useDocumentTitle.tsx";
 import { useScrollToTopOnMount } from "../../shared/hooks/useScrollToTopOnMount.tsx";
 import { useSkjemaState } from "../SkjemaStateContext.tsx";
 import { useInnloggetBruker } from "../useInnloggetBruker.tsx";
-import { ÅrForRefusjon } from "../visningskomponenter/ÅrForRefusjon.tsx";
+import {
+  ÅrForRefusjon,
+  iÅr,
+  iFjor,
+  kanVelgeFjoråret,
+} from "../visningskomponenter/ÅrForRefusjon.tsx";
 import { OmsorgspengerFremgangsindikator } from "../visningskomponenter/OmsorgspengerFremgangsindikator.tsx";
 
 export const RefusjonOmsorgspengerArbeidsgiverSteg1 = () => {
@@ -28,8 +33,6 @@ export const RefusjonOmsorgspengerArbeidsgiverSteg1 = () => {
   const innloggetBruker = useInnloggetBruker();
 
   const navigate = useNavigate();
-  const iÅr = new Date().getFullYear();
-  const iFjor = iÅr - 1;
 
   const { register, formState, watch, handleSubmit, setValue, getValues } =
     useSkjemaState();
@@ -50,6 +53,10 @@ export const RefusjonOmsorgspengerArbeidsgiverSteg1 = () => {
   const { name: harUtbetaltLønnName, ...harUtbetaltLønnRadioGroupProps } =
     register("harUtbetaltLønn");
 
+  const infoOmToSeparateSøknader = kanVelgeFjoråret
+    ? `Du kan kun søke om refusjon innenfor ett kalenderår av gangen.
+       Det betyr at hvis du skal søke om refusjon for perioder i både ${iFjor} og ${iÅr}, må du sende to separate søknader.`
+    : "";
   return (
     <div className="bg-ax-bg-default rounded-md flex flex-col gap-6">
       <Heading level="1" size="large">
@@ -66,8 +73,7 @@ export const RefusjonOmsorgspengerArbeidsgiverSteg1 = () => {
             sykt barn.
           </BodyLong>
           <BodyLong>
-            {`Du kan søke for perioder inntil tre måneder tilbake i tid. Du kan kun søke om refusjon innenfor ett kalenderår av gangen.
-            Det betyr at hvis du skal søke om refusjon for perioder i både ${iFjor} og ${iÅr}, må du sende to separate søknader.`}
+            {`Du kan søke for perioder inntil tre måneder tilbake i tid. ${infoOmToSeparateSøknader}`}
           </BodyLong>
           <BodyLong>
             Du må også sende inn som separate refusjonskrav hvis en har hatt

--- a/app/src/features/refusjon-omsorgspenger/visningskomponenter/ÅrForRefusjon.tsx
+++ b/app/src/features/refusjon-omsorgspenger/visningskomponenter/ÅrForRefusjon.tsx
@@ -1,0 +1,42 @@
+import { Radio, RadioGroup } from "@navikt/ds-react";
+import dayjs from "dayjs";
+import { useEffect } from "react";
+
+import { useSkjemaState } from "../SkjemaStateContext";
+
+const førsteApril = dayjs().month(3).date(1);
+const kanVelgeFjoråret = dayjs().isBefore(førsteApril);
+const iÅr = dayjs().year();
+const iFjor = iÅr - 1;
+
+// Man kan kreve refusjon tre måneder tilbake i tid.
+// Det betyr at man kan søke om refusjon for fjoråret frem til 1. april.
+export const ÅrForRefusjon = () => {
+  const { register, formState, setValue } = useSkjemaState();
+  const { name: årForRefusjonName, ...årForRefusjonRadioGroupProps } =
+    register("årForRefusjon");
+  useEffect(() => {
+    if (!kanVelgeFjoråret) {
+      setValue("årForRefusjon", String(iÅr));
+    }
+  }, []);
+
+  if (!kanVelgeFjoråret) {
+    return null;
+  }
+
+  return (
+    <RadioGroup
+      error={formState.errors.årForRefusjon?.message}
+      legend="Hvilket år søker dere refusjon for?"
+      name={årForRefusjonName}
+    >
+      <Radio value={String(iFjor)} {...årForRefusjonRadioGroupProps}>
+        {iFjor}
+      </Radio>
+      <Radio value={String(iÅr)} {...årForRefusjonRadioGroupProps}>
+        {iÅr}
+      </Radio>
+    </RadioGroup>
+  );
+};

--- a/app/src/features/refusjon-omsorgspenger/visningskomponenter/ÅrForRefusjon.tsx
+++ b/app/src/features/refusjon-omsorgspenger/visningskomponenter/ÅrForRefusjon.tsx
@@ -4,11 +4,10 @@ import { useEffect } from "react";
 
 import { useSkjemaState } from "../SkjemaStateContext";
 
-const førsteApril = dayjs().month(3).date(1);
-const kanVelgeFjoråret = dayjs().isBefore(førsteApril);
-const iÅr = dayjs().year();
-const iFjor = iÅr - 1;
-
+export const førsteApril = dayjs().month(3).date(1);
+export const kanVelgeFjoråret = dayjs().isBefore(førsteApril);
+export const iÅr = dayjs().year();
+export const iFjor = iÅr - 1;
 // Man kan kreve refusjon tre måneder tilbake i tid.
 // Det betyr at man kan søke om refusjon for fjoråret frem til 1. april.
 export const ÅrForRefusjon = () => {

--- a/app/tests/e2e/refusjon-omsorgspenger/valideringer.spec.tsx
+++ b/app/tests/e2e/refusjon-omsorgspenger/valideringer.spec.tsx
@@ -15,6 +15,7 @@ const ORGANISASJONSNUMMER = "123456789";
 
 test.describe("Refusjon Omsorgspenger - Valideringer", () => {
   test.beforeEach(async ({ page }) => {
+    await page.clock.install({ time: new Date("2026-03-15").getTime() });
     await mockInnloggetBruker({ page });
     await mockGrunnbeløp({ page });
     await mockInntektsmeldingForÅr({ page, json: [] });

--- a/app/tests/e2e/refusjon-omsorgspenger/valideringer.spec.tsx
+++ b/app/tests/e2e/refusjon-omsorgspenger/valideringer.spec.tsx
@@ -12,10 +12,12 @@ import { formatDatoKort } from "~/utils";
 
 const VALID_FNR = "16878397960";
 const ORGANISASJONSNUMMER = "123456789";
+const DAGENS_DATO = new Date("2024-03-15").getTime();
+const FJORÅRET = 2025;
 
 test.describe("Refusjon Omsorgspenger - Valideringer", () => {
   test.beforeEach(async ({ page }) => {
-    await page.clock.install({ time: new Date("2026-03-15").getTime() });
+    await page.clock.install({ time: DAGENS_DATO });
     await mockInnloggetBruker({ page });
     await mockGrunnbeløp({ page });
     await mockInntektsmeldingForÅr({ page, json: [] });
@@ -52,7 +54,7 @@ test.describe("Refusjon Omsorgspenger - Valideringer", () => {
     ).toBeVisible();
 
     // Fix the error by selecting year - error should disappear and we can proceed
-    const previousYear = new Date().getFullYear() - 1;
+    const previousYear = FJORÅRET;
     await page.getByRole("radio", { name: String(previousYear) }).click();
 
     // Error should be gone
@@ -86,7 +88,7 @@ test.describe("Refusjon Omsorgspenger - Valideringer", () => {
 
     // Fill step 1
     await page.getByRole("radio", { name: "Ja" }).click();
-    const previousYear = new Date().getFullYear() - 1;
+    const previousYear = FJORÅRET;
     await page.getByRole("radio", { name: String(previousYear) }).click();
     await page.getByRole("button", { name: "Neste steg" }).click();
 
@@ -180,7 +182,7 @@ test.describe("Refusjon Omsorgspenger - Valideringer", () => {
 
     // Fill step 1
     await page.getByRole("radio", { name: "Ja" }).click();
-    const previousYear = new Date().getFullYear() - 1;
+    const previousYear = FJORÅRET;
     await page.getByRole("radio", { name: String(previousYear) }).click();
     await page.getByRole("button", { name: "Neste steg" }).click();
 
@@ -267,7 +269,7 @@ test.describe("Refusjon Omsorgspenger - Valideringer", () => {
 
     // Fill step 1
     await page.getByRole("radio", { name: "Ja" }).click();
-    const previousYear = new Date().getFullYear() - 1;
+    const previousYear = FJORÅRET;
     // 31.12.YYYY
     const endOfYear = new Date(previousYear, 11, 31);
     await page.getByRole("radio", { name: String(previousYear) }).click();
@@ -369,7 +371,7 @@ test.describe("Refusjon Omsorgspenger - Valideringer", () => {
 
     // Fill step 1
     await page.getByRole("radio", { name: "Ja" }).click();
-    const previousYear = new Date().getFullYear() - 1;
+    const previousYear = FJORÅRET;
     // 31.12.YYYY
     const endOfYear = new Date(previousYear, 11, 31);
     await page.getByRole("radio", { name: String(previousYear) }).click();
@@ -504,7 +506,7 @@ test.describe("Refusjon Omsorgspenger - Valideringer", () => {
 
     // Fill step 1
     await page.getByRole("radio", { name: "Ja" }).click();
-    const previousYear = new Date().getFullYear() - 1;
+    const previousYear = FJORÅRET;
     await page.getByRole("radio", { name: String(previousYear) }).click();
     await page.getByRole("button", { name: "Neste steg" }).click();
 
@@ -599,7 +601,7 @@ test.describe("Refusjon Omsorgspenger - Valideringer", () => {
 
     // Fill step 1
     await page.getByRole("radio", { name: "Ja" }).click();
-    const previousYear = new Date().getFullYear() - 1;
+    const previousYear = FJORÅRET;
     await page.getByRole("radio", { name: String(previousYear) }).click();
     await page.getByRole("button", { name: "Neste steg" }).click();
 
@@ -685,7 +687,7 @@ test.describe("Refusjon Omsorgspenger - Valideringer", () => {
 
     // Fill step 1
     await page.getByRole("radio", { name: "Ja" }).click();
-    const previousYear = new Date().getFullYear() - 1;
+    const previousYear = FJORÅRET;
     await page.getByRole("radio", { name: String(previousYear) }).click();
     await page.getByRole("button", { name: "Neste steg" }).click();
 
@@ -763,7 +765,7 @@ test.describe("Refusjon Omsorgspenger - Valideringer", () => {
 
     // Fill step 1
     await page.getByRole("radio", { name: "Ja" }).click();
-    const previousYear = new Date().getFullYear() - 1;
+    const previousYear = FJORÅRET;
     await page.getByRole("radio", { name: String(previousYear) }).click();
     await page.getByRole("button", { name: "Neste steg" }).click();
 
@@ -830,7 +832,7 @@ test.describe("Refusjon Omsorgspenger - Valideringer", () => {
 
     // Fill step 1
     await page.getByRole("radio", { name: "Ja" }).click();
-    const previousYear = new Date().getFullYear() - 1;
+    const previousYear = FJORÅRET;
     await page.getByRole("radio", { name: String(previousYear) }).click();
     await page.getByRole("button", { name: "Neste steg" }).click();
 
@@ -917,7 +919,7 @@ test.describe("Refusjon Omsorgspenger - Valideringer", () => {
 
     // Fill step 1
     await page.getByRole("radio", { name: "Ja" }).click();
-    const previousYear = new Date().getFullYear() - 1;
+    const previousYear = FJORÅRET;
     await page.getByRole("radio", { name: String(previousYear) }).click();
     await page.getByRole("button", { name: "Neste steg" }).click();
 
@@ -1002,7 +1004,7 @@ test.describe("Refusjon Omsorgspenger - Valideringer", () => {
 
     // Fill step 1
     await page.getByRole("radio", { name: "Ja" }).click();
-    const previousYear = new Date().getFullYear() - 1;
+    const previousYear = FJORÅRET;
     await page.getByRole("radio", { name: String(previousYear) }).click();
     await page.getByRole("button", { name: "Neste steg" }).click();
 
@@ -1089,7 +1091,7 @@ test.describe("Refusjon Omsorgspenger - Valideringer", () => {
 
     // Fill step 1
     await page.getByRole("radio", { name: "Ja" }).click();
-    const previousYear = new Date().getFullYear() - 1;
+    const previousYear = FJORÅRET;
     await page.getByRole("radio", { name: String(previousYear) }).click();
     await page.getByRole("button", { name: "Neste steg" }).click();
 
@@ -1162,7 +1164,7 @@ test.describe("Refusjon Omsorgspenger - Valideringer", () => {
 
     // Fill step 1
     await page.getByRole("radio", { name: "Ja" }).click();
-    const previousYear = new Date().getFullYear() - 1;
+    const previousYear = FJORÅRET;
     await page.getByRole("radio", { name: String(previousYear) }).click();
     await page.getByRole("button", { name: "Neste steg" }).click();
 
@@ -1251,7 +1253,7 @@ test.describe("Refusjon Omsorgspenger - Valideringer", () => {
 
     // Fill step 1
     await page.getByRole("radio", { name: "Ja" }).click();
-    const previousYear = new Date().getFullYear() - 1;
+    const previousYear = FJORÅRET;
     await page.getByRole("radio", { name: String(previousYear) }).click();
     await page.getByRole("button", { name: "Neste steg" }).click();
 

--- a/app/tests/e2e/refusjon-omsorgspenger/valideringer.spec.tsx
+++ b/app/tests/e2e/refusjon-omsorgspenger/valideringer.spec.tsx
@@ -12,7 +12,7 @@ import { formatDatoKort } from "~/utils";
 
 const VALID_FNR = "16878397960";
 const ORGANISASJONSNUMMER = "123456789";
-const DAGENS_DATO = new Date("2024-03-15").getTime();
+const DAGENS_DATO = new Date("2026-03-15").getTime();
 const FJORÅRET = 2025;
 
 test.describe("Refusjon Omsorgspenger - Valideringer", () => {

--- a/app/tests/e2e/refusjon-omsorgspenger/år-for-refusjon.spec.tsx
+++ b/app/tests/e2e/refusjon-omsorgspenger/år-for-refusjon.spec.tsx
@@ -1,0 +1,74 @@
+import { expect, test } from "@playwright/test";
+import {
+  mockInnloggetBruker,
+  mockInntektsmeldingForÅr,
+  mockInntektsopplysninger,
+} from "tests/mocks/refusjon-omsorgspenger/utils";
+import { mockGrunnbeløp } from "tests/mocks/shared/utils";
+
+const ORGANISASJONSNUMMER = "123456789";
+
+test.describe("ÅrForRefusjon", () => {
+  test("viser årsvalg med både fjoråret og inneværende år før 1. april, og kan gå videre til steg 2 etter å ha valgt år", async ({
+    page,
+  }) => {
+    await page.clock.install({ time: new Date("2024-03-15") });
+    await mockInnloggetBruker({ page });
+    await mockGrunnbeløp({ page });
+    await mockInntektsmeldingForÅr({ page, json: [] });
+    await mockInntektsopplysninger({ page });
+
+    await page.goto(
+      `/k9-im-dialog/refusjon-omsorgspenger/${ORGANISASJONSNUMMER}/1-intro`,
+    );
+    await expect(
+      page.getByRole("heading", { name: "Om refusjon", exact: true }),
+    ).toBeVisible();
+
+    await expect(page.getByRole("radio", { name: "2023" })).toBeVisible();
+    await expect(page.getByRole("radio", { name: "2024" })).toBeVisible();
+
+    await page.getByRole("radio", { name: "Ja" }).click();
+    await page.getByRole("radio", { name: "2023" }).click();
+    await page.getByRole("button", { name: "Neste steg" }).click();
+
+    await page.waitForURL(
+      `**/k9-im-dialog/refusjon-omsorgspenger/${ORGANISASJONSNUMMER}/2-ansatt-og-arbeidsgiver`,
+      { timeout: 10_000 },
+    );
+    await expect(
+      page.getByRole("heading", { name: "Den ansatte og arbeidsgiver" }),
+    ).toBeVisible();
+  });
+
+  test("skjuler årsvalg etter 1. april og setter inneværende år automatisk, og kan gå videre til steg 2", async ({
+    page,
+  }) => {
+    await page.clock.install({ time: new Date("2024-04-02") });
+    await mockInnloggetBruker({ page });
+    await mockGrunnbeløp({ page });
+    await mockInntektsmeldingForÅr({ page, json: [] });
+    await mockInntektsopplysninger({ page });
+
+    await page.goto(
+      `/k9-im-dialog/refusjon-omsorgspenger/${ORGANISASJONSNUMMER}/1-intro`,
+    );
+    await expect(
+      page.getByRole("heading", { name: "Om refusjon", exact: true }),
+    ).toBeVisible();
+
+    await expect(page.getByRole("radio", { name: "2023" })).not.toBeVisible();
+    await expect(page.getByRole("radio", { name: "2024" })).not.toBeVisible();
+
+    await page.getByRole("radio", { name: "Ja" }).click();
+    await page.getByRole("button", { name: "Neste steg" }).click();
+
+    await page.waitForURL(
+      `**/k9-im-dialog/refusjon-omsorgspenger/${ORGANISASJONSNUMMER}/2-ansatt-og-arbeidsgiver`,
+      { timeout: 10_000 },
+    );
+    await expect(
+      page.getByRole("heading", { name: "Den ansatte og arbeidsgiver" }),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
Man kan kreve refusjons opp til tre måneder tilbake i tid. Etter 1. april kan vi automatisk velge inneværende år som år for refusjon og trenger ikke rendre valget i det hele tatt.