### PR TITLE
Tillate refusjonskrav for 2025 for å teste i Q

### DIFF
--- a/app/src/features/refusjon-omsorgspenger/visningskomponenter/ÅrForRefusjon.tsx
+++ b/app/src/features/refusjon-omsorgspenger/visningskomponenter/ÅrForRefusjon.tsx
@@ -5,7 +5,7 @@ import { useEffect } from "react";
 import { useSkjemaState } from "../SkjemaStateContext";
 
 export const førsteApril = dayjs().month(3).date(1);
-export const kanVelgeFjoråret = dayjs().isBefore(førsteApril);
+export const kanVelgeFjoråret = true; // FAGSYSTEM-431647 tillater midlertidig for å teste i Q
 export const iÅr = dayjs().year();
 export const iFjor = iÅr - 1;
 // Man kan kreve refusjon tre måneder tilbake i tid.

--- a/app/tests/e2e/refusjon-omsorgspenger/år-for-refusjon.spec.tsx
+++ b/app/tests/e2e/refusjon-omsorgspenger/år-for-refusjon.spec.tsx
@@ -9,7 +9,7 @@ import { mockGrunnbeløp } from "tests/mocks/shared/utils";
 const ORGANISASJONSNUMMER = "123456789";
 
 test.describe("ÅrForRefusjon", () => {
-  test("viser årsvalg med både fjoråret og inneværende år før 1. april, og kan gå videre til steg 2 etter å ha valgt år", async ({
+  test.skip("viser årsvalg med både fjoråret og inneværende år før 1. april, og kan gå videre til steg 2 etter å ha valgt år", async ({
     page,
   }) => {
     await page.clock.install({ time: new Date("2024-03-15") });
@@ -41,7 +41,7 @@ test.describe("ÅrForRefusjon", () => {
     ).toBeVisible();
   });
 
-  test("skjuler årsvalg etter 1. april og setter inneværende år automatisk, og kan gå videre til steg 2", async ({
+  test.skip("skjuler årsvalg etter 1. april og setter inneværende år automatisk, og kan gå videre til steg 2", async ({
     page,
   }) => {
     await page.clock.install({ time: new Date("2024-04-02") });


### PR DESCRIPTION
### Behov / Bakgrunn
Mulig første utfordring med stenging av inntektsmelding på altinn :face_with_peeking_eye: Gjelder refusjonskrav for omsorgspengar. AG har sendt im via Altinn for dager i nov/des 2025 i slutten av 2025. Arbeidsgjevar har svart nei på at det er utbetalt for 10 dager + at det er registrert permisjon i aa-reg. AG hadde korrigert permisjonen og har fått beskjed om at han må sende nytt refusjonskrav der han endra til ja på at det er utbetalt 10 dager (dei 10 første dagane var brukt tidlegare på året). Han får ikkje endra via Altinn (der blir han henvist til navno, sjølv om dei skreiv i går at det skulle vere mogleg).

