### PR TITLE
Støtte for avsluttede arbeidsforhold i refusjon OMP

### DIFF
--- a/app/src/features/refusjon-omsorgspenger/api/queries.ts
+++ b/app/src/features/refusjon-omsorgspenger/api/queries.ts
@@ -120,9 +120,6 @@ export const hentArbeidstakerOptions = (fødselsnummer: string, år: string) => 
 };
 
 const hentArbeidstaker = async (fødselsnummer: string, år: string) => {
-  if (!år) {
-    throw new Error("Fødselsnummer og år må være definert");
-  }
   const response = await fetch(
     `${SERVER_URL}/refusjon-omsorgsdager/arbeidstaker`,
     {

--- a/app/src/features/refusjon-omsorgspenger/api/queries.ts
+++ b/app/src/features/refusjon-omsorgspenger/api/queries.ts
@@ -86,7 +86,7 @@ const ArbeidstakerOppslagDtoSchema = z.object({
       organisasjonsnummer: z.string(),
       ansettelsesperiode: z.object({
         fom: z.string(),
-        tom: z.string().optional(),
+        tom: z.string().nullable(),
       }),
     }),
   ),

--- a/app/src/features/refusjon-omsorgspenger/api/queries.ts
+++ b/app/src/features/refusjon-omsorgspenger/api/queries.ts
@@ -84,6 +84,10 @@ const ArbeidstakerOppslagDtoSchema = z.object({
     z.object({
       organisasjonsnavn: z.string(),
       organisasjonsnummer: z.string(),
+      ansettelsesperiode: z.object({
+        fom: z.string(),
+        tom: z.string().optional(),
+      }),
     }),
   ),
 });
@@ -97,15 +101,15 @@ export type ArbeidstakerOppslagFeil =
   | { feilkode: "uventet respons" } // Zod-validering feilet
   | Error; // Programmeringsfeil
 
-export const hentArbeidstakerOptions = (fødselsnummer: string) => {
+export const hentArbeidstakerOptions = (fødselsnummer: string, år: string) => {
   return queryOptions<
     ArbeidstakerOppslagDto,
     ArbeidstakerOppslagFeil,
     ArbeidstakerOppslagDto,
-    ["arbeidstaker-oppslag", string]
+    ["arbeidstaker-oppslag", string, string]
   >({
-    queryKey: ["arbeidstaker-oppslag", fødselsnummer],
-    queryFn: ({ queryKey }) => hentArbeidstaker(queryKey[1]),
+    queryKey: ["arbeidstaker-oppslag", fødselsnummer, år],
+    queryFn: ({ queryKey }) => hentArbeidstaker(queryKey[1], queryKey[2]),
     enabled: idnr(fødselsnummer).status === "valid",
     staleTime: Infinity,
     retry: false,
@@ -115,7 +119,10 @@ export const hentArbeidstakerOptions = (fødselsnummer: string) => {
   });
 };
 
-const hentArbeidstaker = async (fødselsnummer: string) => {
+const hentArbeidstaker = async (fødselsnummer: string, år: string) => {
+  if (!år) {
+    throw new Error("Fødselsnummer og år må være definert");
+  }
   const response = await fetch(
     `${SERVER_URL}/refusjon-omsorgsdager/arbeidstaker`,
     {
@@ -123,6 +130,7 @@ const hentArbeidstaker = async (fødselsnummer: string) => {
       body: JSON.stringify({
         fødselsnummer,
         ytelseType: "OMSORGSPENGER",
+        årstall: Number(år),
       }),
       headers: {
         "Content-Type": "application/json",

--- a/app/src/features/refusjon-omsorgspenger/steg/ArbeidsgiverSeksjon.tsx
+++ b/app/src/features/refusjon-omsorgspenger/steg/ArbeidsgiverSeksjon.tsx
@@ -1,5 +1,6 @@
-import { BodyShort, Label, Select } from "@navikt/ds-react";
+import { BodyShort, Detail, Label, Select, VStack } from "@navikt/ds-react";
 import { useQuery } from "@tanstack/react-query";
+import dayjs from "dayjs";
 import { useEffect } from "react";
 
 import { hentArbeidstakerOptions } from "../api/queries.ts";
@@ -12,8 +13,10 @@ type ArbeidsgiverSeksjonProps = {
 export const ArbeidsgiverSeksjon = ({
   fødselsnummer,
 }: ArbeidsgiverSeksjonProps) => {
-  const { register, formState, setValue } = useSkjemaState();
-  const { data } = useQuery(hentArbeidstakerOptions(fødselsnummer ?? ""));
+  const { register, formState, setValue, getValues } = useSkjemaState();
+  const { data } = useQuery(
+    hentArbeidstakerOptions(fødselsnummer ?? "", getValues("årForRefusjon")),
+  );
 
   useEffect(() => {
     if (data?.arbeidsforhold.length === 1) {
@@ -47,7 +50,7 @@ export const ArbeidsgiverSeksjon = ({
         <option value="">Velg arbeidsforhold</option>
         {data.arbeidsforhold.map((af) => (
           <option key={af.organisasjonsnummer} value={af.organisasjonsnummer}>
-            {af.organisasjonsnavn} ({af.organisasjonsnummer})
+            {`${af.organisasjonsnavn} (org.nr. ${af.organisasjonsnummer})${af.ansettelsesperiode.tom ? ` – avsluttet ${dayjs(af.ansettelsesperiode.tom).format("DD.MM.YYYY")}` : ""}`}
           </option>
         ))}
       </Select>
@@ -59,7 +62,13 @@ export const ArbeidsgiverSeksjon = ({
     <div className="flex gap-4">
       <div className="flex-1">
         <Label>Virksomhetsnavn</Label>
-        <BodyShort>{enkelt.organisasjonsnavn}</BodyShort>
+        <VStack gap="space-2">
+          <BodyShort>{enkelt.organisasjonsnavn}</BodyShort>
+          <Detail>
+            {enkelt.ansettelsesperiode.tom &&
+              `Arbeidsforholdet ble avsluttet ${dayjs(enkelt.ansettelsesperiode.tom).format("DD.MM.YYYY")}`}
+          </Detail>
+        </VStack>
       </div>
       <div className="flex-1">
         <Label>Org.nr. for underenhet</Label>

--- a/app/src/features/refusjon-omsorgspenger/steg/ArbeidsgiverSeksjon.tsx
+++ b/app/src/features/refusjon-omsorgspenger/steg/ArbeidsgiverSeksjon.tsx
@@ -64,10 +64,9 @@ export const ArbeidsgiverSeksjon = ({
         <Label>Virksomhetsnavn</Label>
         <VStack gap="space-2">
           <BodyShort>{enkelt.organisasjonsnavn}</BodyShort>
-          <Detail>
-            {enkelt.ansettelsesperiode.tom &&
-              `Arbeidsforholdet ble avsluttet ${dayjs(enkelt.ansettelsesperiode.tom).format("DD.MM.YYYY")}`}
-          </Detail>
+          {enkelt.ansettelsesperiode.tom && (
+            <Detail>{`Arbeidsforholdet ble avsluttet ${dayjs(enkelt.ansettelsesperiode.tom).format("DD.MM.YYYY")}`}</Detail>
+          )}
         </VStack>
       </div>
       <div className="flex-1">

--- a/app/src/features/refusjon-omsorgspenger/steg/ArbeidsgiverUnntattSeksjon.tsx
+++ b/app/src/features/refusjon-omsorgspenger/steg/ArbeidsgiverUnntattSeksjon.tsx
@@ -53,7 +53,7 @@ export const ArbeidsgiverUnntattSeksjon = () => {
         <option value="">Velg virksomhet</option>
         {data.organisasjoner.map((ag) => (
           <option key={ag.organisasjonsnummer} value={ag.organisasjonsnummer}>
-            {ag.organisasjonsnavn} ({ag.organisasjonsnummer})
+            {`${ag.organisasjonsnavn} (org.nr. ${ag.organisasjonsnummer})`}
           </option>
         ))}
       </Select>

--- a/app/src/features/refusjon-omsorgspenger/steg/NavnVisning.tsx
+++ b/app/src/features/refusjon-omsorgspenger/steg/NavnVisning.tsx
@@ -10,13 +10,16 @@ import {
 import { useSkjemaState } from "../SkjemaStateContext";
 
 export const NavnVisning = () => {
-  const { register, watch } = useSkjemaState();
+  const { register, watch, getValues } = useSkjemaState();
 
   const fødselsnummer = watch("ansattesFødselsnummer");
   const erUnntattAaregisteret = watch("erUnntattAaregisteret");
 
   const { data, error, isLoading } = useQuery(
-    hentArbeidstakerOptions(fødselsnummer ?? ""),
+    hentArbeidstakerOptions(
+      getValues("ansattesFødselsnummer") ?? "",
+      getValues("årForRefusjon"),
+    ),
   );
 
   const { data: ansattNavnData, isLoading: isLoadingNavn } = useQuery(

--- a/app/src/features/refusjon-omsorgspenger/steg/Steg2AnsattOgArbeidsgiver.tsx
+++ b/app/src/features/refusjon-omsorgspenger/steg/Steg2AnsattOgArbeidsgiver.tsx
@@ -46,15 +46,24 @@ export const RefusjonOmsorgspengerArbeidsgiverSteg2 = () => {
 
   const fødselsnummer = watch("ansattesFødselsnummer");
   const erUnntattAaregisteret = watch("erUnntattAaregisteret");
+  const år = getValues("årForRefusjon");
 
   const { data, error } = useQuery(
-    hentArbeidstakerOptions(fødselsnummer ?? ""),
+    hentArbeidstakerOptions(getValues("ansattesFødselsnummer") ?? "", år),
   );
 
   const fantIngenPersoner =
     error && "feilkode" in error && error.feilkode === "fant ingen personer";
   const visUnntattLøype = erUnntattAaregisteret ?? false;
 
+  useEffect(() => {
+    if (!år) {
+      navigate({
+        from: "/refusjon-omsorgspenger/$organisasjonsnummer/2-ansatt-og-arbeidsgiver",
+        to: "../1-intro",
+      });
+    }
+  }, []);
   useEffect(() => {
     setValue("meta.step", 2);
     if (getValues("meta.innsendtSøknadId")) {

--- a/app/tests/mocks/refusjon-omsorgspenger/utils.ts
+++ b/app/tests/mocks/refusjon-omsorgspenger/utils.ts
@@ -43,6 +43,10 @@ export const mockArbeidstakerOppslag = ({
       {
         organisasjonsnavn: "Test Organisasjon",
         organisasjonsnummer: "123456789",
+        ansettelsesperiode: {
+          fom: "2024-01-01",
+          tom: null,
+        },
       },
     ],
   },
@@ -59,6 +63,10 @@ export const mockArbeidstakerOppslag = ({
     arbeidsforhold: Array<{
       organisasjonsnavn: string;
       organisasjonsnummer: string;
+      ansettelsesperiode: {
+        fom: string;
+        tom: string | null;
+      };
     }>;
   };
 }) => {


### PR DESCRIPTION
### Behov / Bakgrunn
Arbeidsgiver har ikke hatt muligheten til å søke på arbeidsforhold som er opphørt siden vi bare har vist arbeidsforhold som er aktive på dagens dato

### Løsning
APIet sender nå med arbeidsforhold som er opphørt det året brukeren har valgt i steg 1. Disse kan velges og markeres med at arbeidsforholdet er avsluttet

### Andre endringer

