### PR TITLE
Feature/søke i arbeidsforhold

### DIFF
--- a/app/src/features/arbeidsgiverinitiert/inngang/VelgArbeidsgiver.tsx
+++ b/app/src/features/arbeidsgiverinitiert/inngang/VelgArbeidsgiver.tsx
@@ -1,9 +1,5 @@
-import { Select } from "@navikt/ds-react";
-import { useFormContext } from "react-hook-form";
-
+import { ComboboxWrapped } from "~/features/shared/react-hook-form-wrappers/ComboboxWrapped";
 import { SlåOppArbeidstakerResponseDto } from "~/types/api-schemas.ts";
-
-import { FormType } from "./types";
 
 export function VelgArbeidsgiver({
   data,
@@ -12,32 +8,27 @@ export function VelgArbeidsgiver({
   data?: SlåOppArbeidstakerResponseDto;
   description?: string;
 }) {
-  const formMethods = useFormContext<FormType>();
-
   if (!data || data.arbeidsforhold.length <= 1) {
     return null;
   }
 
+  const options = data.arbeidsforhold
+    .toSorted((a, b) =>
+      a.organisasjonsnavn.localeCompare(b.organisasjonsnavn, "nb"),
+    )
+    .map((arbeidsforhold) => ({
+      value: arbeidsforhold.organisasjonsnummer,
+      label: `${arbeidsforhold.organisasjonsnavn} (${arbeidsforhold.organisasjonsnummer})`,
+    }));
+
   return (
-    <Select
-      data-testid="steg-0-select-arbeidsgiver"
+    <ComboboxWrapped
+      data-testid="steg-0-combobox-arbeidsgiver"
       description={description}
-      error={formMethods.formState.errors.organisasjonsnummer?.message}
       label="Arbeidsgiver"
-      {...formMethods.register(`organisasjonsnummer`, {
-        required: "Må oppgis",
-      })}
-    >
-      <option value="">Velg Organisasjon</option>
-      {data?.arbeidsforhold.map((arbeidsforhold) => (
-        <option
-          key={arbeidsforhold.organisasjonsnummer}
-          value={arbeidsforhold.organisasjonsnummer}
-        >
-          {arbeidsforhold.organisasjonsnavn} (
-          {arbeidsforhold.organisasjonsnummer})
-        </option>
-      ))}
-    </Select>
+      name="organisasjonsnummer"
+      options={options}
+      rules={{ required: "Må oppgis" }}
+    />
   );
 }

--- a/app/src/features/refusjon-omsorgspenger/steg/ArbeidsgiverSeksjon.tsx
+++ b/app/src/features/refusjon-omsorgspenger/steg/ArbeidsgiverSeksjon.tsx
@@ -1,7 +1,9 @@
-import { BodyShort, Detail, Label, Select, VStack } from "@navikt/ds-react";
+import { BodyShort, Detail, Label, VStack } from "@navikt/ds-react";
 import { useQuery } from "@tanstack/react-query";
 import dayjs from "dayjs";
 import { useEffect } from "react";
+
+import { ComboboxWrapped } from "~/features/shared/react-hook-form-wrappers/ComboboxWrapped";
 
 import { hentArbeidstakerOptions } from "../api/queries.ts";
 import { useSkjemaState } from "../SkjemaStateContext";
@@ -13,7 +15,7 @@ type ArbeidsgiverSeksjonProps = {
 export const ArbeidsgiverSeksjon = ({
   fødselsnummer,
 }: ArbeidsgiverSeksjonProps) => {
-  const { register, formState, setValue, getValues } = useSkjemaState();
+  const { setValue, getValues } = useSkjemaState();
   const { data } = useQuery(
     hentArbeidstakerOptions(fødselsnummer ?? "", getValues("årForRefusjon")),
   );
@@ -34,26 +36,30 @@ export const ArbeidsgiverSeksjon = ({
   if (!data || data.arbeidsforhold.length === 0) return null;
 
   if (data.arbeidsforhold.length > 1) {
+    const options = data.arbeidsforhold
+      .toSorted((a, b) =>
+        a.organisasjonsnavn.localeCompare(b.organisasjonsnavn, "nb"),
+      )
+      .map((af) => ({
+        value: af.organisasjonsnummer,
+        label: `${af.organisasjonsnavn} (org.nr. ${af.organisasjonsnummer})${af.ansettelsesperiode.tom ? ` – avsluttet ${dayjs(af.ansettelsesperiode.tom).format("DD.MM.YYYY")}` : ""}`,
+      }));
+
     return (
-      <Select
+      <ComboboxWrapped
         label="Velg arbeidsforhold"
-        {...register("organisasjonsnummer", {
-          onChange: (e) => {
-            const valgt = data.arbeidsforhold.find(
-              (af) => af.organisasjonsnummer === e.target.value,
-            );
-            setValue("meta.organisasjonsnavn", valgt?.organisasjonsnavn ?? "");
-          },
-        })}
-        error={formState.errors.organisasjonsnummer?.message}
-      >
-        <option value="">Velg arbeidsforhold</option>
-        {data.arbeidsforhold.map((af) => (
-          <option key={af.organisasjonsnummer} value={af.organisasjonsnummer}>
-            {`${af.organisasjonsnavn} (org.nr. ${af.organisasjonsnummer})${af.ansettelsesperiode.tom ? ` – avsluttet ${dayjs(af.ansettelsesperiode.tom).format("DD.MM.YYYY")}` : ""}`}
-          </option>
-        ))}
-      </Select>
+        name="organisasjonsnummer"
+        options={options}
+        onOptionSelected={(valgt) => {
+          const arbeidsforhold = data.arbeidsforhold.find(
+            (af) => af.organisasjonsnummer === valgt?.value,
+          );
+          setValue(
+            "meta.organisasjonsnavn",
+            arbeidsforhold?.organisasjonsnavn ?? "",
+          );
+        }}
+      />
     );
   }
 

--- a/app/src/features/refusjon-omsorgspenger/steg/ArbeidsgiverUnntattSeksjon.tsx
+++ b/app/src/features/refusjon-omsorgspenger/steg/ArbeidsgiverUnntattSeksjon.tsx
@@ -1,12 +1,14 @@
-import { BodyShort, Label, Loader, Select } from "@navikt/ds-react";
+import { BodyShort, Label, Loader } from "@navikt/ds-react";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
+
+import { ComboboxWrapped } from "~/features/shared/react-hook-form-wrappers/ComboboxWrapped";
 
 import { hentArbeidsgiversOrganisasjonerOptions } from "../api/queries.ts";
 import { useSkjemaState } from "../SkjemaStateContext";
 
 export const ArbeidsgiverUnntattSeksjon = () => {
-  const { register, formState, setValue } = useSkjemaState();
+  const { register, setValue } = useSkjemaState();
   const { data, isLoading, error } = useQuery(
     hentArbeidsgiversOrganisasjonerOptions(),
   );
@@ -36,27 +38,30 @@ export const ArbeidsgiverUnntattSeksjon = () => {
   if (!data) return null;
 
   if (data.organisasjoner.length > 1) {
+    const options = data.organisasjoner
+      .toSorted((a, b) =>
+        a.organisasjonsnavn.localeCompare(b.organisasjonsnavn, "nb"),
+      )
+      .map((org) => ({
+        value: org.organisasjonsnummer,
+        label: `${org.organisasjonsnavn} (org.nr. ${org.organisasjonsnummer})`,
+      }));
+
     return (
-      <Select
+      <ComboboxWrapped
         label="Velg virksomhet"
-        {...register("organisasjonsnummer", {
-          value: "",
-          onChange: (e) => {
-            const valgt = data.organisasjoner.find(
-              (org) => org.organisasjonsnummer === e.target.value,
-            );
-            setValue("meta.organisasjonsnavn", valgt?.organisasjonsnavn ?? "");
-          },
-        })}
-        error={formState.errors.organisasjonsnummer?.message}
-      >
-        <option value="">Velg virksomhet</option>
-        {data.organisasjoner.map((ag) => (
-          <option key={ag.organisasjonsnummer} value={ag.organisasjonsnummer}>
-            {`${ag.organisasjonsnavn} (org.nr. ${ag.organisasjonsnummer})`}
-          </option>
-        ))}
-      </Select>
+        name="organisasjonsnummer"
+        options={options}
+        onOptionSelected={(valgt) => {
+          const organisasjon = data.organisasjoner.find(
+            (org) => org.organisasjonsnummer === valgt?.value,
+          );
+          setValue(
+            "meta.organisasjonsnavn",
+            organisasjon?.organisasjonsnavn ?? "",
+          );
+        }}
+      />
     );
   }
 

--- a/app/src/features/refusjon-omsorgspenger/visningskomponenter/ÅrForRefusjon.tsx
+++ b/app/src/features/refusjon-omsorgspenger/visningskomponenter/ÅrForRefusjon.tsx
@@ -11,9 +11,18 @@ export const iFjor = iÅr - 1;
 // Man kan kreve refusjon tre måneder tilbake i tid.
 // Det betyr at man kan søke om refusjon for fjoråret frem til 1. april.
 export const ÅrForRefusjon = () => {
-  const { register, formState, setValue } = useSkjemaState();
-  const { name: årForRefusjonName, ...årForRefusjonRadioGroupProps } =
-    register("årForRefusjon");
+  const { register, formState, setValue, getValues } = useSkjemaState();
+  const { name: årForRefusjonName, ...årForRefusjonRadioGroupProps } = register(
+    "årForRefusjon",
+    {
+      onChange: (e) => {
+        if (e.target.value !== getValues("årForRefusjon")) {
+          setValue("organisasjonsnummer", undefined);
+          setValue("meta.organisasjonsnavn", undefined);
+        }
+      },
+    },
+  );
   useEffect(() => {
     if (!kanVelgeFjoråret) {
       setValue("årForRefusjon", String(iÅr));

--- a/app/src/features/refusjon-omsorgspenger/visningskomponenter/ÅrForRefusjon.tsx
+++ b/app/src/features/refusjon-omsorgspenger/visningskomponenter/ÅrForRefusjon.tsx
@@ -11,15 +11,13 @@ export const iFjor = iÅr - 1;
 // Man kan kreve refusjon tre måneder tilbake i tid.
 // Det betyr at man kan søke om refusjon for fjoråret frem til 1. april.
 export const ÅrForRefusjon = () => {
-  const { register, formState, setValue, getValues } = useSkjemaState();
+  const { register, formState, setValue } = useSkjemaState();
   const { name: årForRefusjonName, ...årForRefusjonRadioGroupProps } = register(
     "årForRefusjon",
     {
-      onChange: (e) => {
-        if (e.target.value !== getValues("årForRefusjon")) {
-          setValue("organisasjonsnummer", undefined);
-          setValue("meta.organisasjonsnavn", undefined);
-        }
+      onChange: () => {
+        setValue("organisasjonsnummer", undefined);
+        setValue("meta.organisasjonsnavn", undefined);
       },
     },
   );

--- a/app/src/features/shared/react-hook-form-wrappers/ComboboxWrapped.tsx
+++ b/app/src/features/shared/react-hook-form-wrappers/ComboboxWrapped.tsx
@@ -80,6 +80,7 @@ export function ComboboxWrapped({
           field.onChange(nyttValgtAlternativ?.value ?? verdi);
           onOptionSelected?.(nyttValgtAlternativ);
         } else {
+          // eslint-disable-next-line unicorn/no-useless-undefined
           field.onChange(undefined);
           onOptionSelected?.();
         }

--- a/app/src/features/shared/react-hook-form-wrappers/ComboboxWrapped.tsx
+++ b/app/src/features/shared/react-hook-form-wrappers/ComboboxWrapped.tsx
@@ -1,0 +1,89 @@
+import {
+  type ComboboxProps,
+  UNSAFE_Combobox as Combobox,
+} from "@navikt/ds-react";
+import { useController } from "react-hook-form";
+
+export type ComboboxWrappedOption = {
+  label: string;
+  value: string;
+};
+
+type ComboboxWrappedProps = {
+  name: string;
+  label: React.ReactNode;
+  description?: React.ReactNode;
+  options: ComboboxWrappedOption[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- usikker på hvordan rules skal types, og om det er såå viktig.
+  rules?: any;
+  shouldUnregister?: boolean;
+  onOptionSelected?: (option?: ComboboxWrappedOption) => void;
+} & Omit<
+  ComboboxProps,
+  | "options"
+  | "label"
+  | "description"
+  | "selectedOptions"
+  | "onToggleSelected"
+  | "value"
+  | "onChange"
+  | "name"
+  | "error"
+  | "onBlur"
+>;
+
+/**
+ * Wrapper rundt Aksel sin `UNSAFE_Combobox` som lar brukeren søke i en liste med
+ * `{ label, value }`-alternativer (f.eks. navn og org.nr.), integrert med react-hook-form.
+ * Kun single-select er støttet.
+ *
+ * Vi lar Combobox styre sin egen søketekst internt (uncontrolled `value`), og lar den
+ * innebygde visningen av valgt alternativ (via `selectedOptions`) vise navnet/label etter
+ * at et valg er gjort – i tråd med hvordan Aksel sin single-select-variant er designet.
+ */
+export function ComboboxWrapped({
+  name,
+  label,
+  description,
+  options,
+  rules = {},
+  shouldUnregister,
+  onOptionSelected,
+  ...comboboxProps
+}: ComboboxWrappedProps) {
+  const { field, fieldState } = useController({
+    name,
+    rules,
+    shouldUnregister,
+  });
+
+  const valgtAlternativ = options.find(
+    (option) => option.value === field.value,
+  );
+
+  return (
+    <Combobox
+      {...comboboxProps}
+      label={label}
+      description={description}
+      options={options}
+      error={fieldState.error?.message}
+      name={field.name}
+      ref={field.ref}
+      onBlur={field.onBlur}
+      selectedOptions={valgtAlternativ ? [valgtAlternativ] : []}
+      onToggleSelected={(verdi, erValgt) => {
+        if (erValgt) {
+          const nyttValgtAlternativ = options.find(
+            (option) => option.value === verdi,
+          );
+          field.onChange(nyttValgtAlternativ?.value ?? verdi);
+          onOptionSelected?.(nyttValgtAlternativ);
+        } else {
+          field.onChange("");
+          onOptionSelected?.();
+        }
+      }}
+    />
+  );
+}

--- a/app/src/features/shared/react-hook-form-wrappers/ComboboxWrapped.tsx
+++ b/app/src/features/shared/react-hook-form-wrappers/ComboboxWrapped.tsx
@@ -2,7 +2,7 @@ import {
   type ComboboxProps,
   UNSAFE_Combobox as Combobox,
 } from "@navikt/ds-react";
-import { useController } from "react-hook-form";
+import { type RegisterOptions, useController } from "react-hook-form";
 
 export type ComboboxWrappedOption = {
   label: string;
@@ -14,8 +14,7 @@ type ComboboxWrappedProps = {
   label: React.ReactNode;
   description?: React.ReactNode;
   options: ComboboxWrappedOption[];
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- usikker på hvordan rules skal types, og om det er såå viktig.
-  rules?: any;
+  rules?: RegisterOptions;
   shouldUnregister?: boolean;
   onOptionSelected?: (option?: ComboboxWrappedOption) => void;
 } & Omit<

--- a/app/src/features/shared/react-hook-form-wrappers/ComboboxWrapped.tsx
+++ b/app/src/features/shared/react-hook-form-wrappers/ComboboxWrapped.tsx
@@ -80,7 +80,7 @@ export function ComboboxWrapped({
           field.onChange(nyttValgtAlternativ?.value ?? verdi);
           onOptionSelected?.(nyttValgtAlternativ);
         } else {
-          field.onChange("");
+          field.onChange(undefined);
           onOptionSelected?.();
         }
       }}

--- a/app/tests/e2e/arbeidsgiverinitiert/nyansatt/agi-forste-fravaersdag-validering.spec.tsx
+++ b/app/tests/e2e/arbeidsgiverinitiert/nyansatt/agi-forste-fravaersdag-validering.spec.tsx
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { velgFraCombobox } from "tests/e2e/utils";
 import { agiOpplysningerResponseNyAnsatt } from "tests/mocks/arbeidsgiverinitiert/nyansatt/agi-opplysninger";
 import {
   mockAGIOpplysninger,
@@ -30,9 +31,12 @@ test.describe("AGI Første fraværsdag validering", () => {
     await page.getByLabel("Ansattes fødselsnummer").fill(FAKE_FNR);
     await page.getByLabel("Første fraværsdag").fill("01.04.2024");
     await page.getByRole("button", { name: "Hent opplysninger" }).click();
-    await page
-      .getByTestId("steg-0-select-arbeidsgiver")
-      .selectOption("974652293");
+    await velgFraCombobox({
+      page,
+      testId: "steg-0-combobox-arbeidsgiver",
+      søketekst: "974652293",
+      alternativNavn: /974652293/,
+    });
     await page.getByRole("button", { name: "Opprett inntektsmelding" }).click();
 
     // Gå gjennom dine opplysninger
@@ -99,9 +103,12 @@ test.describe("AGI Første fraværsdag validering", () => {
     await page.getByLabel("Ansattes fødselsnummer").fill(FAKE_FNR);
     await page.getByLabel("Første fraværsdag").fill("01.04.2024");
     await page.getByRole("button", { name: "Hent opplysninger" }).click();
-    await page
-      .getByTestId("steg-0-select-arbeidsgiver")
-      .selectOption("974652293");
+    await velgFraCombobox({
+      page,
+      testId: "steg-0-combobox-arbeidsgiver",
+      søketekst: "974652293",
+      alternativNavn: /974652293/,
+    });
     await page.getByRole("button", { name: "Opprett inntektsmelding" }).click();
 
     // Gå gjennom dine opplysninger
@@ -164,9 +171,12 @@ test.describe("AGI Første fraværsdag validering", () => {
     await page.getByLabel("Ansattes fødselsnummer").fill(FAKE_FNR);
     await page.getByLabel("Første fraværsdag").fill("01.04.2024");
     await page.getByRole("button", { name: "Hent opplysninger" }).click();
-    await page
-      .getByTestId("steg-0-select-arbeidsgiver")
-      .selectOption("974652293");
+    await velgFraCombobox({
+      page,
+      testId: "steg-0-combobox-arbeidsgiver",
+      søketekst: "974652293",
+      alternativNavn: /974652293/,
+    });
     await page.getByRole("button", { name: "Opprett inntektsmelding" }).click();
 
     // Gå gjennom dine opplysninger
@@ -220,9 +230,12 @@ test.describe("AGI Første fraværsdag validering", () => {
     await page.getByLabel("Ansattes fødselsnummer").fill(FAKE_FNR);
     await page.getByLabel("Første fraværsdag").fill("01.04.2024");
     await page.getByRole("button", { name: "Hent opplysninger" }).click();
-    await page
-      .getByTestId("steg-0-select-arbeidsgiver")
-      .selectOption("974652293");
+    await velgFraCombobox({
+      page,
+      testId: "steg-0-combobox-arbeidsgiver",
+      søketekst: "974652293",
+      alternativNavn: /974652293/,
+    });
     await page.getByRole("button", { name: "Opprett inntektsmelding" }).click();
 
     // Gå gjennom dine opplysninger

--- a/app/tests/e2e/arbeidsgiverinitiert/nyansatt/agi-happy-path.spec.tsx
+++ b/app/tests/e2e/arbeidsgiverinitiert/nyansatt/agi-happy-path.spec.tsx
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { velgFraCombobox } from "tests/e2e/utils";
 import { agiOpplysningerResponseNyAnsatt } from "tests/mocks/arbeidsgiverinitiert/nyansatt/agi-opplysninger";
 import { agiSendInntektsmeldingResponse } from "tests/mocks/arbeidsgiverinitiert/nyansatt/agi-send-inntektsmelding";
 import {
@@ -36,9 +37,12 @@ test.describe("AGI Happy Path", () => {
     await mockAGIOpplysninger({ page, json: agiOpplysningerResponseNyAnsatt });
 
     // Velg arbeidsgiver
-    await page
-      .getByTestId("steg-0-select-arbeidsgiver")
-      .selectOption("974652293");
+    await velgFraCombobox({
+      page,
+      testId: "steg-0-combobox-arbeidsgiver",
+      søketekst: "974652293",
+      alternativNavn: /974652293/,
+    });
 
     // Klikk "Opprett inntektsmelding"
     await page.getByRole("button", { name: "Opprett inntektsmelding" }).click();
@@ -97,9 +101,12 @@ test.describe("AGI Happy Path", () => {
 
     await mockAGIOpplysninger({ page, json: agiOpplysningerResponseNyAnsatt });
 
-    await page
-      .getByTestId("steg-0-select-arbeidsgiver")
-      .selectOption("974652293");
+    await velgFraCombobox({
+      page,
+      testId: "steg-0-combobox-arbeidsgiver",
+      søketekst: "974652293",
+      alternativNavn: /974652293/,
+    });
     await page.getByRole("button", { name: "Opprett inntektsmelding" }).click();
 
     // Fyll ut dine opplysninger
@@ -149,9 +156,12 @@ test.describe("AGI Happy Path", () => {
 
     await mockAGIOpplysninger({ page, json: agiOpplysningerResponseNyAnsatt });
 
-    await page
-      .getByTestId("steg-0-select-arbeidsgiver")
-      .selectOption("974652293");
+    await velgFraCombobox({
+      page,
+      testId: "steg-0-combobox-arbeidsgiver",
+      søketekst: "974652293",
+      alternativNavn: /974652293/,
+    });
     await page.getByRole("button", { name: "Opprett inntektsmelding" }).click();
 
     // Fyll ut dine opplysninger

--- a/app/tests/e2e/arbeidsgiverinitiert/nyansatt/agi-ulike-scenarier.spec.tsx
+++ b/app/tests/e2e/arbeidsgiverinitiert/nyansatt/agi-ulike-scenarier.spec.tsx
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { velgFraCombobox } from "tests/e2e/utils";
 import {
   agiOpplysningerAlternativYtelse,
   agiOpplysningerResponseNyAnsatt,
@@ -35,9 +36,12 @@ test.describe("AGI Ulike scenarier", () => {
       json: agiOpplysningerAlternativYtelse,
     });
 
-    await page
-      .getByTestId("steg-0-select-arbeidsgiver")
-      .selectOption("974652293");
+    await velgFraCombobox({
+      page,
+      testId: "steg-0-combobox-arbeidsgiver",
+      søketekst: "974652293",
+      alternativNavn: /974652293/,
+    });
     await page.getByRole("button", { name: "Opprett inntektsmelding" }).click();
 
     await page.getByLabel("Telefon").fill("98765432");
@@ -79,9 +83,12 @@ test.describe("AGI Ulike scenarier", () => {
 
     await mockAGIOpplysninger({ page, json: agiOpplysningerResponseNyAnsatt });
 
-    await page
-      .getByTestId("steg-0-select-arbeidsgiver")
-      .selectOption("974652293");
+    await velgFraCombobox({
+      page,
+      testId: "steg-0-combobox-arbeidsgiver",
+      søketekst: "974652293",
+      alternativNavn: /974652293/,
+    });
     await page.getByRole("button", { name: "Opprett inntektsmelding" }).click();
 
     const testNavn = "Ola Nordmann";
@@ -131,9 +138,12 @@ test.describe("AGI Ulike scenarier", () => {
 
     await mockAGIOpplysninger({ page, json: agiOpplysningerResponseNyAnsatt });
 
-    await page
-      .getByTestId("steg-0-select-arbeidsgiver")
-      .selectOption("974652293");
+    await velgFraCombobox({
+      page,
+      testId: "steg-0-combobox-arbeidsgiver",
+      søketekst: "974652293",
+      alternativNavn: /974652293/,
+    });
     await page.getByRole("button", { name: "Opprett inntektsmelding" }).click();
 
     await page.getByLabel("Navn").fill("Ola Nordmann");
@@ -219,9 +229,12 @@ test.describe("AGI Ulike scenarier", () => {
 
     await mockAGIOpplysninger({ page, json: agiOpplysningerResponseNyAnsatt });
 
-    await page
-      .getByTestId("steg-0-select-arbeidsgiver")
-      .selectOption("974652293");
+    await velgFraCombobox({
+      page,
+      testId: "steg-0-combobox-arbeidsgiver",
+      søketekst: "974652293",
+      alternativNavn: /974652293/,
+    });
     await page.getByRole("button", { name: "Opprett inntektsmelding" }).click();
 
     await page.getByLabel("Telefon").fill("98765432");

--- a/app/tests/e2e/arbeidsgiverinitiert/nyansatt/agi-valideringer.spec.tsx
+++ b/app/tests/e2e/arbeidsgiverinitiert/nyansatt/agi-valideringer.spec.tsx
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { velgFraCombobox } from "tests/e2e/utils";
 import { agiOpplysningerResponseNyAnsatt } from "tests/mocks/arbeidsgiverinitiert/nyansatt/agi-opplysninger";
 import {
   expectError,
@@ -59,9 +60,12 @@ test.describe("AGI Valideringer", () => {
 
     await mockAGIOpplysninger({ page, json: agiOpplysningerResponseNyAnsatt });
 
-    await page
-      .getByTestId("steg-0-select-arbeidsgiver")
-      .selectOption("974652293");
+    await velgFraCombobox({
+      page,
+      testId: "steg-0-combobox-arbeidsgiver",
+      søketekst: "974652293",
+      alternativNavn: /974652293/,
+    });
     await page.getByRole("button", { name: "Opprett inntektsmelding" }).click();
 
     // Verifiser at vi er på dine-opplysninger siden
@@ -88,9 +92,12 @@ test.describe("AGI Valideringer", () => {
 
     await mockAGIOpplysninger({ page, json: agiOpplysningerResponseNyAnsatt });
 
-    await page
-      .getByTestId("steg-0-select-arbeidsgiver")
-      .selectOption("974652293");
+    await velgFraCombobox({
+      page,
+      testId: "steg-0-combobox-arbeidsgiver",
+      søketekst: "974652293",
+      alternativNavn: /974652293/,
+    });
     await page.getByRole("button", { name: "Opprett inntektsmelding" }).click();
 
     await page.getByLabel("Telefon").fill("98765432");
@@ -115,9 +122,12 @@ test.describe("AGI Valideringer", () => {
 
     await mockAGIOpplysninger({ page, json: agiOpplysningerResponseNyAnsatt });
 
-    await page
-      .getByTestId("steg-0-select-arbeidsgiver")
-      .selectOption("974652293");
+    await velgFraCombobox({
+      page,
+      testId: "steg-0-combobox-arbeidsgiver",
+      søketekst: "974652293",
+      alternativNavn: /974652293/,
+    });
     await page.getByRole("button", { name: "Opprett inntektsmelding" }).click();
 
     await page.getByLabel("Telefon").fill("98765432");
@@ -151,7 +161,9 @@ test.describe("AGI Valideringer", () => {
     await page.getByRole("button", { name: "Hent opplysninger" }).click();
 
     // Siden mock har flere arbeidsforhold, skal dropdown vises
-    await expect(page.getByTestId("steg-0-select-arbeidsgiver")).toBeVisible();
+    await expect(
+      page.getByTestId("steg-0-combobox-arbeidsgiver"),
+    ).toBeVisible();
 
     // Verifiser at "Opprett inntektsmelding" knappen vises
     await expect(
@@ -174,9 +186,12 @@ test.describe("AGI Valideringer", () => {
 
     await mockAGIOpplysninger({ page, json: agiOpplysningerResponseNyAnsatt });
 
-    await page
-      .getByTestId("steg-0-select-arbeidsgiver")
-      .selectOption("974652293");
+    await velgFraCombobox({
+      page,
+      testId: "steg-0-combobox-arbeidsgiver",
+      søketekst: "974652293",
+      alternativNavn: /974652293/,
+    });
     await page.getByRole("button", { name: "Opprett inntektsmelding" }).click();
 
     await page.getByLabel("Telefon").fill("98765432");

--- a/app/tests/e2e/arbeidsgiverinitiert/nyansatt/arbeidsgiverinitiert.spec.tsx
+++ b/app/tests/e2e/arbeidsgiverinitiert/nyansatt/arbeidsgiverinitiert.spec.tsx
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { velgFraCombobox } from "tests/e2e/utils";
 import { enkeltOpplysningerResponse } from "tests/mocks/inntektsmelding/opplysninger";
 import {
   expectError,
@@ -45,9 +46,12 @@ test("Ny ansatt", async ({ page }) => {
     },
   );
 
-  await page
-    .getByTestId("steg-0-select-arbeidsgiver")
-    .selectOption("974652293");
+  await velgFraCombobox({
+    page,
+    testId: "steg-0-combobox-arbeidsgiver",
+    søketekst: "974652293",
+    alternativNavn: /974652293/,
+  });
 
   await page.getByRole("button", { name: "Opprett inntektsmelding" }).click();
   await expect(
@@ -81,9 +85,12 @@ test("Skal ikke kunne velge NEI på refusjon hvis AGI og nyansatt", async ({
     },
   );
 
-  await page
-    .getByTestId("steg-0-select-arbeidsgiver")
-    .selectOption("974652293");
+  await velgFraCombobox({
+    page,
+    testId: "steg-0-combobox-arbeidsgiver",
+    søketekst: "974652293",
+    alternativNavn: /974652293/,
+  });
 
   await page.getByRole("button", { name: "Opprett inntektsmelding" }).click();
   await page.getByLabel("Telefon").fill("13371337");

--- a/app/tests/e2e/utils.ts
+++ b/app/tests/e2e/utils.ts
@@ -1,0 +1,21 @@
+import { Page } from "@playwright/test";
+
+/**
+ * Velger et alternativ fra en Combobox (UNSAFE_Combobox) ved å søke og klikke
+ * på riktig alternativ i nedtrekkslisten.
+ */
+export async function velgFraCombobox({
+  page,
+  testId,
+  søketekst,
+  alternativNavn,
+}: {
+  page: Page;
+  testId: string;
+  søketekst: string;
+  alternativNavn: string | RegExp;
+}) {
+  const combobox = page.getByTestId(testId);
+  await combobox.fill(søketekst);
+  await page.getByRole("option", { name: alternativNavn }).click();
+}

--- a/app/tests/e2e/utils.ts
+++ b/app/tests/e2e/utils.ts
@@ -16,6 +16,11 @@ export async function velgFraCombobox({
   alternativNavn: string | RegExp;
 }) {
   const combobox = page.getByTestId(testId);
+  await combobox.click();
   await combobox.fill(søketekst);
-  await page.getByRole("option", { name: alternativNavn }).click();
+
+  await page
+    .getByRole("listbox")
+    .getByRole("option", { name: alternativNavn })
+    .click();
 }


### PR DESCRIPTION
### Behov / Bakgrunn
Enkelte arbeidsgivere har tilgang til ekstremt mange organisasjoner. Hovedsaklig et problem i unntatt aa-register da man ikke vet hvilke organisasjoner arbeidstaker er knyttet til.

### Løsning
Bytte select med combobox, som gjør at man kan søke

### Andre endringer
Nullstille organisasjonsnummer for arbeidsgiver hvis vi bytter årstall, for tilgjengelige arbeidsgivere kan ha endret seg

